### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/ragadox/authentication/configurations/SecurityConfiguration.java
+++ b/src/main/java/com/ragadox/authentication/configurations/SecurityConfiguration.java
@@ -29,7 +29,6 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(sessionManagement ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)


### PR DESCRIPTION
Potential fix for [https://github.com/RAGAdox/authentication/security/code-scanning/1](https://github.com/RAGAdox/authentication/security/code-scanning/1)

To fix the problem, we need to enable CSRF protection in the `SecurityConfiguration` class. This involves removing the line that disables CSRF protection. By default, Spring Security enables CSRF protection, so we do not need to add any additional configuration to enable it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
